### PR TITLE
Add dashboard default redirect

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -4,7 +4,10 @@ import { Routes, RouterModule } from '@angular/router';
 import { DashComponent } from './dash/dash.component';
 
 
-const routes: Routes = [{path: 'dashboard', component: DashComponent}];
+const routes: Routes = [
+  { path: '', redirectTo: 'dashboard', pathMatch: 'full' },
+  { path: 'dashboard', component: DashComponent }
+];
 
 @NgModule({
   imports: [RouterModule.forRoot(routes)],


### PR DESCRIPTION
## Summary
- add default redirect to dashboard route

## Testing
- `npm test -- --watch=false` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68401d5ea91c832dbd41ee3e0a762547