### PR TITLE
Replace title test with navigation check

### DIFF
--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -26,10 +26,10 @@ describe('AppComponent', () => {
     expect(app.title).toEqual('store-admin-panel');
   });
 
-  it('should render title', () => {
+  it('should render navigation component', () => {
     const fixture = TestBed.createComponent(AppComponent);
     fixture.detectChanges();
     const compiled = fixture.nativeElement;
-    expect(compiled.querySelector('.content span').textContent).toContain('store-admin-panel app is running!');
+    expect(compiled.querySelector('app-nav')).toBeTruthy();
   });
 });


### PR DESCRIPTION
## Summary
- update app component test to verify `<app-nav>` renders

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68401d60de54832dbd1e38240834c3e6