### PR TITLE
Fix IE note in browserslist

### DIFF
--- a/browserslist
+++ b/browserslist
@@ -9,4 +9,5 @@
 last 2 versions
 Firefox ESR
 not dead
-not IE 9-11 # For IE 9-11 support, remove 'not'.
+not IE 9-11
+# For IE 9-11 support, remove 'not'.


### PR DESCRIPTION
## Summary
- split the IE note in `browserslist` into two lines for clarity

## Testing
- `npm test` *(fails: ng not found)*
- `npm run lint` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68401d5fe4b4832da77cbf8aa66c5354