### PR TITLE
Add summary score widget

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -17,6 +17,7 @@ import { DashComponent } from './dash/dash.component';
 import { MatGridListModule } from '@angular/material/grid-list';
 import { MatCardModule } from '@angular/material/card';
 import { MatMenuModule } from '@angular/material/menu';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { CardComponent } from './card/card.component';
 
 import { ProductSalesChartComponent } from './charts/product-sales-chart/product-sales-chart.component';
@@ -28,6 +29,7 @@ import { MatTableModule } from '@angular/material/table';
 import { MatPaginatorModule } from '@angular/material/paginator';
 import { MatSortModule } from '@angular/material/sort';
 import { MiniCardComponent } from './mini-card/mini-card.component';
+import { SummaryScoreWidgetComponent } from './summary-score-widget/summary-score-widget.component';
 
 @NgModule({
   declarations: [
@@ -40,7 +42,8 @@ import { MiniCardComponent } from './mini-card/mini-card.component';
     AnnualSalesChartComponent,
     StoreSessionsChartComponent,
     OrdersTableComponent,
-    MiniCardComponent
+    MiniCardComponent,
+    SummaryScoreWidgetComponent
   ],
   imports: [
     BrowserModule,
@@ -58,7 +61,8 @@ import { MiniCardComponent } from './mini-card/mini-card.component';
     MatMenuModule,
     MatTableModule,
     MatPaginatorModule,
-    MatSortModule
+    MatSortModule,
+    MatProgressSpinnerModule
   ],
   providers: [],
   bootstrap: [AppComponent]

--- a/src/app/dash/dash.component.html
+++ b/src/app/dash/dash.component.html
@@ -7,6 +7,9 @@
       <app-mini-card [title]="mc.title" [value]="mc.value" [color]="mc.color" [icon]="mc.icon"
         [percentValue]="mc.percentValue"></app-mini-card>
     </mat-grid-tile>
+    <mat-grid-tile [colspan]="( cardLayout | async )?.miniCard.cols" [rowspan]="( cardLayout | async )?.miniCard.rows">
+      <app-summary-score-widget></app-summary-score-widget>
+    </mat-grid-tile>
     <!--Charts-->
     <mat-grid-tile [colspan]="( cardLayout | async )?.chart.cols" [rowspan]="( cardLayout | async )?.chart.rows">
       <app-card title="Monthly Revenue">

--- a/src/app/dash/dash.component.ts
+++ b/src/app/dash/dash.component.ts
@@ -50,4 +50,5 @@ export class DashComponent implements OnInit {
       }
     });
   }
+
 }

--- a/src/app/services/summary-score.service.ts
+++ b/src/app/services/summary-score.service.ts
@@ -1,0 +1,14 @@
+import { Injectable } from '@angular/core';
+import { Observable, of } from 'rxjs';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class SummaryScoreService {
+
+  constructor() { }
+
+  getSummaryScore(): Observable<number> {
+    return of(75); // mocked score between 0 and 100
+  }
+}

--- a/src/app/summary-score-widget/summary-score-widget.component.html
+++ b/src/app/summary-score-widget/summary-score-widget.component.html
@@ -1,0 +1,11 @@
+<mat-card class="dashboard-card score-card">
+  <mat-card-header>
+    <mat-card-title>Summary Score</mat-card-title>
+  </mat-card-header>
+  <mat-card-content class="dashboard-card-content">
+    <div class="score-container">
+      <mat-progress-spinner mode="determinate" [value]="score" diameter="100"></mat-progress-spinner>
+      <div class="score-text">{{score}}</div>
+    </div>
+  </mat-card-content>
+</mat-card>

--- a/src/app/summary-score-widget/summary-score-widget.component.scss
+++ b/src/app/summary-score-widget/summary-score-widget.component.scss
@@ -1,0 +1,13 @@
+.score-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+}
+
+.score-text {
+  margin-top: 10px;
+  font-size: 24px;
+  font-weight: 500;
+}

--- a/src/app/summary-score-widget/summary-score-widget.component.spec.ts
+++ b/src/app/summary-score-widget/summary-score-widget.component.spec.ts
@@ -1,0 +1,35 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { MatCardModule } from '@angular/material/card';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+
+import { SummaryScoreWidgetComponent } from './summary-score-widget.component';
+import { SummaryScoreService } from '../services/summary-score.service';
+import { of } from 'rxjs';
+
+class MockSummaryScoreService {
+  getSummaryScore() { return of(50); }
+}
+
+describe('SummaryScoreWidgetComponent', () => {
+  let component: SummaryScoreWidgetComponent;
+  let fixture: ComponentFixture<SummaryScoreWidgetComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ SummaryScoreWidgetComponent ],
+      imports: [ MatCardModule, MatProgressSpinnerModule ],
+      providers: [ { provide: SummaryScoreService, useClass: MockSummaryScoreService } ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(SummaryScoreWidgetComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/summary-score-widget/summary-score-widget.component.ts
+++ b/src/app/summary-score-widget/summary-score-widget.component.ts
@@ -1,0 +1,17 @@
+import { Component, OnInit } from '@angular/core';
+import { SummaryScoreService } from '../services/summary-score.service';
+
+@Component({
+  selector: 'app-summary-score-widget',
+  templateUrl: './summary-score-widget.component.html',
+  styleUrls: ['./summary-score-widget.component.scss']
+})
+export class SummaryScoreWidgetComponent implements OnInit {
+  score = 0;
+
+  constructor(private summaryScoreService: SummaryScoreService) {}
+
+  ngOnInit(): void {
+    this.summaryScoreService.getSummaryScore().subscribe(value => this.score = value);
+  }
+}


### PR DESCRIPTION
## Summary
- add mock summary score service
- create SummaryScoreWidget component
- show the summary score on dashboard
- register widget and progress spinner module

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68401f167f18832d897eec12b6bcdb58